### PR TITLE
Compatibility with node 6.5 crypto APIs. 

### DIFF
--- a/lib/cipher.js
+++ b/lib/cipher.js
@@ -24,8 +24,8 @@ module.exports = {
 			if( err )
 				cb( err );		
 			else try {
-				var ciph = crypto.createCipheriv( CRYPTO_ALGORITHM, key.toString( 'binary' ), iv.toString( 'binary' ) );
-				var ct = ciph.update( plaintext.toString( 'binary' ) );
+				var ciph = crypto.createCipheriv( CRYPTO_ALGORITHM, key, iv );
+				var ct = ciph.update( plaintext );
 				
 				if( typeof ct === 'string' ) {
 					// node 0.8.x and below
@@ -51,8 +51,8 @@ module.exports = {
 
 	decipher: function( key, xmitted, cb ) {
 
-		var dec = crypto.createDecipheriv( CRYPTO_ALGORITHM, key.toString( 'binary' ), xmitted.slice( 0, IV_SIZE ).toString( 'binary' ) ),
-			res = dec.update( xmitted.slice( IV_SIZE ).toString( 'binary' ) );
+		var dec = crypto.createDecipheriv( CRYPTO_ALGORITHM, key, xmitted.slice( 0, IV_SIZE ) ),
+			res = dec.update( xmitted.slice( IV_SIZE ) );
 
 		if( typeof res === 'string' ) {
 			// node 0.8.x and below


### PR DESCRIPTION
Fixes #2. 

This PR makes 2 changes to cipher.js: 

1. it changes the calls to `crypto.createCipheriv()` and `crypto.createDecipheriv()` to pass Buffers instead of binary-encoded Strings. This change is backwards-compatible down to Node [v0.7.x](https://nodejs.org/docs/v0.7.12/api/crypto.html#crypto_crypto_createcipheriv_algorithm_key_iv), breaking on [v0.6.x](https://nodejs.org/docs/v0.6.21/api/crypto.html#crypto_crypto_createcipheriv_algorithm_key_iv).
2. it changes the calls to `cipher.update()` and `decipher.update()` to pass Buffers instead of binary-encoded Strings. This change is backwards-compatible down to Node [v0.9.x](https://nodejs.org/docs/v0.9.12/api/crypto.html#crypto_cipher_update_data_input_encoding_output_encoding), before which it might break (see [v0.8.x](https://nodejs.org/docs/v0.8.28/api/crypto.html#crypto_cipher_update_data_input_encoding_output_encoding)). 

This change may be merged directly if you are comfortable with Galette working only on v0.9.x+. If that's the case, we can add an `engine` field to `package.json` to ensure that it is only used with compatible versions of Node, and we can also remove the conditional code in cipher.js. 

